### PR TITLE
Add direct routing configuration to ECS module

### DIFF
--- a/docs/dual-nlb-routing.md
+++ b/docs/dual-nlb-routing.md
@@ -1,0 +1,190 @@
+# Dual NLB Routing Architecture
+
+This document explains the dual NLB routing architecture that allows traffic to flow through Kong Gateway or directly to Hello-Service.
+
+## Architecture Overview
+
+```
+                    ┌─────────────────┐
+                    │   API Gateway   │
+                    └─────────┬───────┘
+                              │
+                    ┌─────────▼───────┐
+                    │      ALB        │
+                    └─────────┬───────┘
+                              │
+                 ┌────────────┼────────────┐
+                 │            │            │
+                 ▼            ▼            ▼
+         ┌──────────────┐  Weighted   ┌──────────────┐
+         │   NLB_1      │  Routing    │   NLB_2      │
+         │ (Kong Path)  │             │ (Direct Path)│
+         └──────┬───────┘             └──────┬───────┘
+                │                            │
+                ▼                            ▼
+         ┌──────────────┐             ┌──────────────┐
+         │ Kong Gateway │────────────▶│Hello-Service │
+         └──────────────┘             └──────────────┘
+```
+
+## Traffic Flows
+
+### Option 1: Through Kong Gateway (NLB_1)
+- **Traffic**: `ALB → NLB_1:8000 → Kong:8000 → Hello-Service:8080`
+- **Health**: `ALB health check → NLB_1:8100 → Kong:8100/status/ready`
+
+### Option 2: Direct to Hello-Service (NLB_2)  
+- **Traffic**: `ALB → NLB_2:8000 → Hello-Service:8080`
+- **Health**: `ALB health check → NLB_2:8080 → Hello-Service:8080/actuator/health`
+
+## Configuration
+
+### Enable Direct Routing
+
+```hcl
+# In terraform.tfvars
+direct_routing_enabled = true
+kong_enabled          = true
+
+# Traffic distribution (must add up to 100)
+kong_traffic_weight   = 70    # 70% through Kong
+direct_traffic_weight = 30    # 30% direct to Hello-Service
+```
+
+### Common Usage Scenarios
+
+#### 1. Kong Gateway Only (Default)
+```hcl
+kong_enabled          = true
+direct_routing_enabled = false
+kong_traffic_weight   = 100
+direct_traffic_weight = 0
+```
+
+#### 2. Direct Access Only
+```hcl
+kong_enabled          = false
+direct_routing_enabled = true
+kong_traffic_weight   = 0
+direct_traffic_weight = 100
+```
+
+#### 3. Gradual Migration (Blue-Green)
+```hcl
+# Start with Kong
+kong_enabled          = true
+direct_routing_enabled = true
+kong_traffic_weight   = 100
+direct_traffic_weight = 0
+
+# Gradually shift traffic
+kong_traffic_weight   = 50
+direct_traffic_weight = 50
+
+# Complete migration to direct
+kong_traffic_weight   = 0
+direct_traffic_weight = 100
+```
+
+#### 4. A/B Testing
+```hcl
+kong_enabled          = true
+direct_routing_enabled = true
+kong_traffic_weight   = 80    # 80% production traffic
+direct_traffic_weight = 20    # 20% test traffic
+```
+
+## Load Balancer Details
+
+### Kong NLB (NLB_1)
+- **Name**: `sbxservice-dev-kong-nlb`
+- **Listeners**: 
+  - Port 8000 → Kong Gateway traffic
+  - Port 8100 → Kong Gateway health checks
+- **Target Groups**:
+  - `sbxservice-dev-kong-traffic` (port 8000)
+  - `sbxservice-dev-kong-health` (port 8100)
+
+### Direct NLB (NLB_2)
+- **Name**: `sbxservice-dev-direct-nlb`  
+- **Listeners**:
+  - Port 8000 → Hello-Service traffic
+- **Target Groups**:
+  - `sbxservice-dev-direct-traffic` (port 8080)
+
+## Monitoring and Observability
+
+### Health Check Endpoints
+
+| Component | Health Check URL | Expected Response |
+|-----------|------------------|-------------------|
+| Kong Gateway | `http://kong:8100/status/ready` | 200 OK |
+| Hello-Service (via Kong) | `http://kong:8000/actuator/health` | 200 OK |
+| Hello-Service (direct) | `http://hello-service:8080/actuator/health` | 200 OK |
+
+### CloudWatch Metrics
+
+Monitor the following metrics to understand traffic distribution:
+- ALB target group health metrics
+- NLB target group health metrics  
+- Kong Gateway metrics (if enabled)
+- ECS service metrics for both paths
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Health Check Failures**
+   - Verify Kong Gateway status API is enabled
+   - Check Hello-Service actuator endpoints
+   - Ensure security groups allow health check traffic
+
+2. **Traffic Not Routing**
+   - Verify ALB target group attachments
+   - Check NLB listener configurations
+   - Validate ECS service registrations
+
+3. **Weight Distribution Issues**
+   - Ensure weights add up to 100%
+   - Check ALB target group distribution
+   - Monitor ALB access logs for traffic patterns
+
+### Validation Commands
+
+```bash
+# Check ALB target health
+aws elbv2 describe-target-health --target-group-arn <alb-target-group-arn>
+
+# Check Kong NLB target health  
+aws elbv2 describe-target-health --target-group-arn <kong-target-group-arn>
+
+# Check Direct NLB target health
+aws elbv2 describe-target-health --target-group-arn <direct-target-group-arn>
+
+# Test endpoints directly
+curl -H "Host: your-domain.com" http://<alb-dns-name>/actuator/health
+```
+
+## Security Considerations
+
+### Network Security
+- All NLBs are internal (not internet-facing)
+- Traffic flows through ALB security groups
+- ECS services remain in private subnets
+
+### Kong Gateway Bypass
+- Direct routing bypasses Kong's security policies
+- Ensure Hello-Service has appropriate security measures
+- Consider keeping Kong for authentication/authorization
+
+## Cost Optimization
+
+### Resource Usage
+- **Kong Enabled + Direct**: 2 NLBs, additional target groups
+- **Kong Only**: 1 NLB, Kong containers
+- **Direct Only**: 1 NLB, no Kong overhead
+
+### Recommendations
+- Use direct routing for internal/trusted traffic
+- Use Kong Gateway for external/API traffic
+- Monitor cost impact of dual NLB setup

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -148,6 +148,11 @@ module "ecs" {
   # Kong Gateway configuration
   kong_enabled   = var.kong_enabled
   kong_app_count = 1
+
+  # Direct routing configuration
+  direct_routing_enabled = var.direct_routing_enabled
+  kong_traffic_weight    = var.kong_traffic_weight
+  direct_traffic_weight  = var.direct_traffic_weight
 }
 
 # Route53 A record for ALB custom domain
@@ -241,6 +246,25 @@ output "kong_service_name" {
 output "kong_enabled" {
   description = "Whether Kong Gateway is enabled"
   value       = var.kong_enabled
+}
+
+# Direct routing outputs
+output "direct_routing_enabled" {
+  description = "Whether direct routing is enabled"
+  value       = var.direct_routing_enabled
+}
+
+output "direct_nlb_dns_name" {
+  description = "DNS name of the Direct Network Load Balancer"
+  value       = module.ecs.direct_nlb_dns_name
+}
+
+output "traffic_routing_weights" {
+  description = "Current traffic routing weights"
+  value = {
+    kong_weight   = var.kong_traffic_weight
+    direct_weight = var.direct_traffic_weight
+  }
 }
 
 # Service Discovery outputs

--- a/terraform/modules/ecs/outputs.tf
+++ b/terraform/modules/ecs/outputs.tf
@@ -85,6 +85,22 @@ output "kong_nlb_health_target_group_arn" {
   value       = var.kong_enabled ? aws_lb_target_group.kong_health[0].arn : null
 }
 
+# Direct NLB outputs
+output "direct_nlb_arn" {
+  description = "ARN of the Direct Network Load Balancer"
+  value       = var.direct_routing_enabled ? aws_lb.direct_nlb[0].arn : null
+}
+
+output "direct_nlb_dns_name" {
+  description = "DNS name of the Direct Network Load Balancer"
+  value       = var.direct_routing_enabled ? aws_lb.direct_nlb[0].dns_name : null
+}
+
+output "direct_nlb_target_group_arn" {
+  description = "ARN of the Direct NLB target group for Hello-Service traffic (port 8080)"
+  value       = var.direct_routing_enabled ? aws_lb_target_group.direct[0].arn : null
+}
+
 # Kong Gateway secrets outputs
 output "kong_cluster_cert_secret_arn" {
   description = "ARN of the Kong Gateway cluster certificate secret"

--- a/terraform/modules/ecs/variables.tf
+++ b/terraform/modules/ecs/variables.tf
@@ -101,4 +101,31 @@ variable "kong_app_count" {
   description = "Number of Kong Gateway containers to run"
   type        = number
   default     = 1
+}
+
+# Direct routing variables
+variable "direct_routing_enabled" {
+  description = "Whether to enable direct routing to Hello-Service (bypassing Kong Gateway)"
+  type        = bool
+  default     = false
+}
+
+variable "kong_traffic_weight" {
+  description = "Percentage of traffic to send through Kong Gateway (0-100)"
+  type        = number
+  default     = 100
+  validation {
+    condition     = var.kong_traffic_weight >= 0 && var.kong_traffic_weight <= 100
+    error_message = "Kong traffic weight must be between 0 and 100."
+  }
+}
+
+variable "direct_traffic_weight" {
+  description = "Percentage of traffic to send directly to Hello-Service (0-100)"
+  type        = number
+  default     = 0
+  validation {
+    condition     = var.direct_traffic_weight >= 0 && var.direct_traffic_weight <= 100
+    error_message = "Direct traffic weight must be between 0 and 100."
+  }
 } 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -61,6 +61,24 @@ variable "kong_enabled" {
   default     = true
 }
 
+variable "direct_routing_enabled" {
+  description = "Whether to enable direct routing to Hello-Service (bypassing Kong Gateway)"
+  type        = bool
+  default     = false
+}
+
+variable "kong_traffic_weight" {
+  description = "Percentage of traffic to send through Kong Gateway (0-100)"
+  type        = number
+  default     = 100
+}
+
+variable "direct_traffic_weight" {
+  description = "Percentage of traffic to send directly to Hello-Service (0-100)"
+  type        = number
+  default     = 0
+}
+
 variable "vpc_cidr" {
   description = "CIDR block for the VPC"
   type        = string


### PR DESCRIPTION
- Introduced variables for direct routing, including enabling/disabling the feature and traffic weight settings.
- Updated the ECS module to support a new Network Load Balancer (NLB) for direct access to Hello-Service, bypassing Kong Gateway.
- Enhanced outputs to include details for the Direct NLB and its target group.
- Adjusted existing resources to accommodate the new direct routing functionality, ensuring proper integration with the load balancer architecture.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a second NLB and wiring to enable optional direct routing to Hello-Service, plus variables/outputs to control and observe traffic split vs. Kong.
> 
> - **Infrastructure (Terraform/ECS module)**
>   - Add Direct NLB (`aws_lb.direct_nlb`), listener (`aws_lb_listener.direct_nlb` on 8000), and target group (`aws_lb_target_group.direct` on 8080) with health checks.
>   - Attach ALB target group to both NLBs via ENIs (`aws_lb_target_group_attachment.kong_nlb`, `...direct_nlb`) enabling dual-path routing.
>   - Update ECS service to register Hello-Service with direct NLB target group when `direct_routing_enabled`.
>   - Add new variables for direct routing and traffic weights: `direct_routing_enabled`, `kong_traffic_weight`, `direct_traffic_weight` (with validations in module).
>   - Extend dependencies to ensure listeners/targets exist before service registration.
> - **Root module**
>   - Wire new variables through to ECS module and expose new outputs: `direct_routing_enabled`, `direct_nlb_dns_name`, `traffic_routing_weights`.
> - **Module outputs**
>   - Expose Direct NLB details: `direct_nlb_arn`, `direct_nlb_dns_name`, `direct_nlb_target_group_arn`.
> - **Docs**
>   - Add `docs/dual-nlb-routing.md` describing architecture, flows, config examples, monitoring, and troubleshooting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfa2d14668e92d07bb153ffa0476f4eec76a6b81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->